### PR TITLE
updating-latest-image-on-every-push-to-master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: reqres
           IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG_LATEST: ${{ 'latest' }}
+
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG_LATEST .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG_LATEST


### PR DESCRIPTION
This workflow will now build the docker image and push to AWS ECR with two different tags `latest` and `{commit_sha}`